### PR TITLE
Stopped getting package name from build settings

### DIFF
--- a/RAGESS/RAGESS/Sources/SourceKitClient/CompilerArgumentsGenerator.swift
+++ b/RAGESS/RAGESS/Sources/SourceKitClient/CompilerArgumentsGenerator.swift
@@ -184,10 +184,6 @@ public struct CompilerArgumentsGenerator {
     }
 
     func getPackageName(sourceFilePath: String, buildSettings: [String: String]) -> String? {
-        if let moduleName = buildSettings["PRODUCT_MODULE_NAME"] {
-            return moduleName
-        }
-
         let fileManager = FileManager.default
         var currentDirectory = URL(fileURLWithPath: sourceFilePath).deletingLastPathComponent()
 


### PR DESCRIPTION
Previously, the “PRODUCT_MODULE_NAME” in the build settings was taken as the package name, but since the "-" in the name were replaced by "_", it was not appropriate to treat it as a package name.