### PR TITLE
Added functionality to monitor a `.app` directory

### DIFF
--- a/RAGESS/RAGESS/Sources/DebugView/MonitorClient.swift
+++ b/RAGESS/RAGESS/Sources/DebugView/MonitorClient.swift
@@ -1,5 +1,5 @@
 //
-//  DerivedDataMonitor.swift
+//  MonitorClient.swift
 //
 //
 //  Created by Ockey12 on 2024/05/20

--- a/RAGESS/RAGESS/Sources/MonitorClient/Monitor.swift
+++ b/RAGESS/RAGESS/Sources/MonitorClient/Monitor.swift
@@ -41,9 +41,9 @@ class Monitor {
 
         source?.resume()
 
-#if DEBUG
-        print("\(#file) - \(#function): Start monitoring \(directoryPath)")
-#endif
+        #if DEBUG
+            print("\(#file) - \(#function): Start monitoring \(directoryPath)")
+        #endif
     }
 
     func stopMonitoring() {

--- a/RAGESS/RAGESS/Sources/MonitorClient/Monitor.swift
+++ b/RAGESS/RAGESS/Sources/MonitorClient/Monitor.swift
@@ -40,10 +40,17 @@ class Monitor {
         }
 
         source?.resume()
+
+#if DEBUG
+        print("\(#file) - \(#function): Start monitoring \(directoryPath)")
+#endif
     }
 
     func stopMonitoring() {
         source?.cancel()
         source = nil
+        #if DEBUG
+            print("\(#file) - \(#function): Stop monitoring \(directoryPath)")
+        #endif
     }
 }

--- a/RAGESS/RAGESS/Sources/RAGESSView/RAGESSReducer.swift
+++ b/RAGESS/RAGESS/Sources/RAGESSView/RAGESSReducer.swift
@@ -295,4 +295,23 @@ extension RAGESSReducer {
 
         return declarationObjects
     }
+
+    func findAppPaths(in directoryPath: String) -> [String] {
+        let fileManager = FileManager.default
+        let directoryURL = URL(filePath: directoryPath)
+
+        guard let enumerator = fileManager.enumerator(at: directoryURL, includingPropertiesForKeys: nil) else {
+            return []
+        }
+
+        var appPaths: [String] = []
+
+        while let url = enumerator.nextObject() as? URL {
+            if url.pathExtension == "app" {
+                appPaths.append(url.path())
+            }
+        }
+
+        return appPaths
+    }
 }

--- a/RAGESS/RAGESS/Sources/RAGESSView/RAGESSReducer.swift
+++ b/RAGESS/RAGESS/Sources/RAGESSView/RAGESSReducer.swift
@@ -85,19 +85,7 @@ public struct RAGESSReducer {
                 #endif
 
                 state.projectRootDirectoryPath = url.path()
-//                state.loadingTaskKindBuffer.append(.sourceFiles)
 
-//                return .run { [
-//                    projectRootDirectoryPath = state.projectRootDirectoryPath,
-//                    ignoredDirectories = state.ignoredDirectories
-//                ] send in
-//                    await send(.sourceFileResponse(Result {
-//                        try await sourceFileClient.getXcodeObjects(
-//                            rootDirectoryPath: projectRootDirectoryPath,
-//                            ignoredDirectories: ignoredDirectories
-//                        )
-//                    }))
-//                }
                 return .send(.extractSourceFiles)
 
             case let .projectDirectorySelectorResponse(.failure(error)):
@@ -288,10 +276,6 @@ public struct RAGESSReducer {
 
                 return .run { send in
                     for appPath in appPaths {
-//                        #if DEBUG
-//                        print("Start monitoring \(appPath)")
-//                        #endif
-
                         for await _ in monitorClient.start(directoryPath: appPath) {
                             await send(.detectedDirectoryChange)
                         }
@@ -299,17 +283,6 @@ public struct RAGESSReducer {
                 }
 
             case .detectedDirectoryChange:
-//                return .run { [
-//                    projectRootDirectoryPath = state.projectRootDirectoryPath,
-//                    ignoredDirectories = state.ignoredDirectories
-//                ] send in
-//                    await send(.sourceFileResponse(Result {
-//                        try await sourceFileClient.getXcodeObjects(
-//                            rootDirectoryPath: projectRootDirectoryPath,
-//                            ignoredDirectories: ignoredDirectories
-//                        )
-//                    }))
-//                }
                 return .send(.extractSourceFiles)
                     .debounce(id: CancelID.detectedBuildSucceeded,
                               for: 1.0,

--- a/RAGESS/RAGESS/Sources/RAGESSView/RAGESSReducer.swift
+++ b/RAGESS/RAGESS/Sources/RAGESSView/RAGESSReducer.swift
@@ -267,9 +267,9 @@ public struct RAGESSReducer {
 
             case .startMonitoring:
                 guard let buildDirectoryPath = state.buildSettings["BUILD_DIR"] else {
-#if DEBUG
-                    print("ERROR in \(#file) - \(#line): Cannot \"BUILD_DIR\" key.")
-#endif
+                    #if DEBUG
+                        print("ERROR in \(#file) - \(#line): Cannot \"BUILD_DIR\" key.")
+                    #endif
                     return .none
                 }
                 let appPaths = findAppPaths(in: buildDirectoryPath)
@@ -284,9 +284,10 @@ public struct RAGESSReducer {
 
             case .detectedDirectoryChange:
                 return .send(.extractSourceFiles)
-                    .debounce(id: CancelID.detectedBuildSucceeded,
-                              for: 1.0,
-                              scheduler: self.mainQueue
+                    .debounce(
+                        id: CancelID.detectedBuildSucceeded,
+                        for: 1.0,
+                        scheduler: self.mainQueue
                     )
 
             case .binding:

--- a/RAGESS/RAGESS/Sources/RAGESSView/RAGESSReducer.swift
+++ b/RAGESS/RAGESS/Sources/RAGESSView/RAGESSReducer.swift
@@ -267,18 +267,21 @@ public struct RAGESSReducer {
 
             case .startMonitoring:
                 guard let buildDirectoryPath = state.buildSettings["BUILD_DIR"] else {
-                    #if DEBUG
-                        print("ERROR in \(#file) - \(#line): Cannot \"BUILD_DIR\" key.")
-                    #endif
+                    print("ERROR in \(#file) - \(#line): Cannot find \"BUILD_DIR\" key.")
                     return .none
                 }
                 let appPaths = findAppPaths(in: buildDirectoryPath)
 
+                guard !appPaths.isEmpty else {
+                    print("ERROR in \(#file) - \(#line): Cannot find \".app\" directory.")
+                    return .none
+                }
+
                 return .run { send in
-                    for appPath in appPaths {
-                        for await _ in monitorClient.start(directoryPath: appPath) {
-                            await send(.detectedDirectoryChange)
-                        }
+                    // FIXME: Monitoring multiple `.app` directories.
+                    // FIXME: Reset monitoring if project root directory changes.
+                    for await _ in monitorClient.start(directoryPath: appPaths[0]) {
+                        await send(.detectedDirectoryChange)
                     }
                 }
 


### PR DESCRIPTION
# What's new
- Monitor the `.app` directory and extract dependencies each time a change is detected.

# What's done
- `MonitorClient` was introduced to `RAGESSReducer`.

# Future tasks
- Monitoring multiple `.app` directories.
- Reset monitoring if project root directory changes.
