### PR TITLE
Moved time measurement start code

### DIFF
--- a/RAGESS/RAGESS/Sources/RAGESSView/RAGESSReducer.swift
+++ b/RAGESS/RAGESS/Sources/RAGESSView/RAGESSReducer.swift
@@ -96,7 +96,6 @@ public struct RAGESSReducer {
                 #endif
 
                 state.projectRootDirectoryPath = url.path()
-                state.processStartTime = CFAbsoluteTimeGetCurrent()
 
                 return .send(.extractSourceFiles)
 
@@ -105,6 +104,7 @@ public struct RAGESSReducer {
                 return .none
 
             case .extractSourceFiles:
+                state.processStartTime = CFAbsoluteTimeGetCurrent()
                 state.loadingTaskKindBuffer.append(.sourceFiles)
 
                 return .run { [


### PR DESCRIPTION
# What's new
- 

# What's done
- The processing time was measured only when the target project was selected for the first time, so it was modified to also measure the time when changes are detected and processed again.

# Future tasks
- 
