### PR TITLE
Fixed compiler arguments

### DIFF
--- a/RAGESS/RAGESS/Sources/SourceKitClient/CompilerArgumentsGenerator.swift
+++ b/RAGESS/RAGESS/Sources/SourceKitClient/CompilerArgumentsGenerator.swift
@@ -47,7 +47,6 @@ extension CompilerArgumentsClient: DependencyKey {
                 return NSString(string: sourceDirectory).lastPathComponent
             }
 
-
             while sourceDirectory != "/" {
                 guard let package = packages.filter({ $0.name == packageName }).first else {
                     sourceDirectory = NSString(string: sourceDirectory).deletingLastPathComponent
@@ -550,7 +549,7 @@ public struct CompilerArgumentsGenerator {
         guard !packages.isEmpty else {
             return NSString(string: sourceDirectory).lastPathComponent
         }
-        let packageName = getPackageName(sourceFilePath: sourceFilePath, buildSettings: buildSettings) 
+        let packageName = getPackageName(sourceFilePath: sourceFilePath, buildSettings: buildSettings)
 
         while sourceDirectory != "/" {
             guard let package = packages.filter({ $0.name == packageName }).first else {

--- a/RAGESS/RAGESS/Sources/SourceKitClient/CompilerArgumentsGenerator.swift
+++ b/RAGESS/RAGESS/Sources/SourceKitClient/CompilerArgumentsGenerator.swift
@@ -39,12 +39,14 @@ extension CompilerArgumentsClient: DependencyKey {
             return nil
         }
 
-        @Sendable func getModuleName(sourceFilePath: String, packages: [PackageObject], buildSettings: [String: String]) -> String? {
+        @Sendable func getModuleName(sourceFilePath: String, packages: [PackageObject], buildSettings: [String: String]) -> String {
+            var sourceDirectory = NSString(string: sourceFilePath).deletingLastPathComponent
+
             guard !packages.isEmpty,
                   let packageName = getPackageName(sourceFilePath: sourceFilePath, buildSettings: buildSettings) else {
-                return nil
+                return NSString(string: sourceDirectory).lastPathComponent
             }
-            var sourceDirectory = NSString(string: sourceFilePath).deletingLastPathComponent
+
 
             while sourceDirectory != "/" {
                 guard let package = packages.filter({ $0.name == packageName }).first else {
@@ -62,7 +64,7 @@ extension CompilerArgumentsClient: DependencyKey {
                 sourceDirectory = NSString(string: sourceDirectory).deletingLastPathComponent
             }
 
-            return nil
+            return NSString(string: sourceDirectory).lastPathComponent
         }
 
         @Sendable func getModuleMapPaths(derivedDataPath: String) -> [String] {
@@ -204,9 +206,7 @@ extension CompilerArgumentsClient: DependencyKey {
                 guard let packageName = getPackageName(sourceFilePath: targetFilePath, buildSettings: buildSettings) else {
                     throw CompilerArgumentGenerationError.notFoundPackageName
                 }
-                guard let moduleName = getModuleName(sourceFilePath: targetFilePath, packages: packages, buildSettings: buildSettings) else {
-                    throw CompilerArgumentGenerationError.notFoundModuleName
-                }
+                let moduleName = getModuleName(sourceFilePath: targetFilePath, packages: packages, buildSettings: buildSettings)
                 guard let buildDirectory = buildSettings["BUILD_DIR"] else {
                     throw CompilerArgumentGenerationError.notFoundBuildDirectory
                 }
@@ -378,12 +378,8 @@ public struct CompilerArgumentsGenerator {
     let packages: [PackageObject]
 
     public func generateArguments() throws -> [String] {
-        guard let packageName = getPackageName(sourceFilePath: targetFilePath, buildSettings: buildSettings) else {
-            throw CompilerArgumentGenerationError.notFoundPackageName
-        }
-        guard let moduleName = getModuleName(sourceFilePath: targetFilePath, packages: packages, buildSettings: buildSettings) else {
-            throw CompilerArgumentGenerationError.notFoundModuleName
-        }
+        let packageName = getPackageName(sourceFilePath: targetFilePath, buildSettings: buildSettings)
+        let moduleName = getModuleName(sourceFilePath: targetFilePath, packages: packages, buildSettings: buildSettings)
         guard let buildDirectory = buildSettings["BUILD_DIR"] else {
             throw CompilerArgumentGenerationError.notFoundBuildDirectory
         }
@@ -533,7 +529,7 @@ public struct CompilerArgumentsGenerator {
         return arguments
     }
 
-    func getPackageName(sourceFilePath: String, buildSettings: [String: String]) -> String? {
+    func getPackageName(sourceFilePath: String, buildSettings: [String: String]) -> String {
         let fileManager = FileManager.default
         var currentDirectory = URL(fileURLWithPath: sourceFilePath).deletingLastPathComponent()
 
@@ -544,15 +540,17 @@ public struct CompilerArgumentsGenerator {
             }
             currentDirectory = currentDirectory.deletingLastPathComponent()
         }
-        return nil
+//        return nil
+        return NSString(string: NSString(string: sourceFilePath).deletingLastPathComponent).lastPathComponent
     }
 
-    func getModuleName(sourceFilePath: String, packages: [PackageObject], buildSettings: [String: String]) -> String? {
-        guard !packages.isEmpty,
-              let packageName = getPackageName(sourceFilePath: sourceFilePath, buildSettings: buildSettings) else {
-            return nil
-        }
+    func getModuleName(sourceFilePath: String, packages: [PackageObject], buildSettings: [String: String]) -> String {
         var sourceDirectory = NSString(string: sourceFilePath).deletingLastPathComponent
+
+        guard !packages.isEmpty else {
+            return NSString(string: sourceDirectory).lastPathComponent
+        }
+        let packageName = getPackageName(sourceFilePath: sourceFilePath, buildSettings: buildSettings) 
 
         while sourceDirectory != "/" {
             guard let package = packages.filter({ $0.name == packageName }).first else {
@@ -570,7 +568,7 @@ public struct CompilerArgumentsGenerator {
             sourceDirectory = NSString(string: sourceDirectory).deletingLastPathComponent
         }
 
-        return nil
+        return NSString(string: sourceDirectory).lastPathComponent
     }
 
     func getModuleMapPaths(derivedDataPath: String) -> [String] {


### PR DESCRIPTION
# What's new
- Projects that are not multi-modularized in SPM can now be analyzed.
- Code for entry points outside of packages can now also be analyzed.

# What's done
- If the package or module name cannot be obtained, the directory name is used.

# Future tasks
- The module name used for files not included in the package may be the project name without “.xcodeproj”.
